### PR TITLE
Api macros

### DIFF
--- a/Source/RealtimeMeshComponent/Public/RealtimeMeshCollision.h
+++ b/Source/RealtimeMeshComponent/Public/RealtimeMeshCollision.h
@@ -169,7 +169,7 @@ public:
 
 
 USTRUCT(BlueprintType)
-struct FRealtimeMeshSimpleGeometry
+struct REALTIMEMESHCOMPONENT_API FRealtimeMeshSimpleGeometry
 {
 	GENERATED_BODY()
 private:

--- a/Source/RealtimeMeshComponent/Public/RealtimeMeshCollision.h
+++ b/Source/RealtimeMeshComponent/Public/RealtimeMeshCollision.h
@@ -240,7 +240,7 @@ public:
 
 
 UCLASS()
-class URealtimeMeshSimpleGeometryFunctionLibrary : public UBlueprintFunctionLibrary
+class REALTIMEMESHCOMPONENT_API URealtimeMeshSimpleGeometryFunctionLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
expose functions to api, otherwise the linker complains about missing symbols