### PR TITLE
deletion: log warning: saving num sectiongroups

### DIFF
--- a/Source/RealtimeMeshComponent/Private/Data/RealtimeMeshLOD.cpp
+++ b/Source/RealtimeMeshComponent/Private/Data/RealtimeMeshLOD.cpp
@@ -194,8 +194,6 @@ namespace RealtimeMesh
 			}
 		}
 		
-		UE_LOG(LogTemp, Warning, TEXT("RMSectionGroup Saving:%d NumSectionGroups:%d"), Ar.IsSaving()? 1 : 0, SectionGroups.Num());
-		
 		Ar << Config;
 		Ar << LocalBounds;
 		return true;

--- a/Source/RealtimeMeshComponent/Private/Data/RealtimeMeshSectionGroup.cpp
+++ b/Source/RealtimeMeshComponent/Private/Data/RealtimeMeshSectionGroup.cpp
@@ -249,8 +249,6 @@ namespace RealtimeMesh
 			}
 		}
 		
-		UE_LOG(LogTemp, Warning, TEXT("RMSection Saving:%d NumSections:%d"), Ar.IsSaving()? 1 : 0, Sections.Num());
-		
 		Ar << LocalBounds;
 		Ar << InUseRange;
 		return true;


### PR DESCRIPTION
quite verbose for me, I have 200 procedurally generated asteroids. Has this warning a reason? If yes, maybe change to `Display`