### PR TITLE
UE5.2 compatibility

### DIFF
--- a/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshComponentProxy.cpp
+++ b/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshComponentProxy.cpp
@@ -6,10 +6,12 @@
 #include "Materials/Material.h"
 #include "PhysicsEngine/BodySetup.h"
 //#include "TessellationRendering.h"
+#include "MaterialDomain.h"
 #include "PrimitiveSceneProxy.h"
 #include "UnrealEngine.h"
 #include "SceneManagement.h"
 #include "RayTracingInstance.h"
+#include "Materials/MaterialRenderProxy.h"
 #include "RenderProxy/RealtimeMeshLODProxy.h"
 
 
@@ -291,7 +293,11 @@ namespace RealtimeMesh
 							RayTracingInstance.InstanceTransforms.Add(LocalToWorld);
 							
 							RayTracingInstance.Materials.Add(Batch);
-							RayTracingInstance.BuildInstanceMaskAndFlags(FeatureLevel);
+							// API Change: Removed the need to call BuildInstanceMaskAndFlags and
+							// BuildRayTracingInstanceMaskAndFlags functions manually in GetXXRayTracingInstance. They
+							// will be called in the renderer module. All functions manually called have been removed.
+							// Removed the RENDER_API public API for those functions in RayTracingInstance.h.
+							// RayTracingInstance.BuildInstanceMaskAndFlags(FeatureLevel);
 							OutRayTracingInstances.Add(RayTracingInstance);
 						},
 						GetUniformBuffer(),

--- a/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshSectionGroupProxy.cpp
+++ b/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshSectionGroupProxy.cpp
@@ -1,6 +1,8 @@
 ﻿// Copyright TriAxis Games, L.L.C. All Rights Reserved.
 
 #include "RenderProxy/RealtimeMeshSectionGroupProxy.h"
+
+#include "MaterialDomain.h"
 #include "RenderProxy/RealtimeMeshLODProxy.h"
 #include "RenderProxy/RealtimeMeshProxy.h"
 #include "RenderProxy/RealtimeMeshSectionProxy.h"

--- a/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshVertexFactory.cpp
+++ b/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshVertexFactory.cpp
@@ -5,6 +5,9 @@
 =============================================================================*/
 
 #include "RenderProxy/RealtimeMeshVertexFactory.h"
+#include "DataDrivenShaderPlatformInfo.h"
+#include "MaterialDomain.h"
+#include "MeshDrawShaderBindings.h"
 #include "SceneView.h"
 #include "MeshBatch.h"
 #include "SpeedTreeWind.h"

--- a/Source/RealtimeMeshComponent/Public/Data/RealtimeMeshDataTypes.h
+++ b/Source/RealtimeMeshComponent/Public/Data/RealtimeMeshDataTypes.h
@@ -61,7 +61,7 @@ namespace RealtimeMesh
 		
 		friend FORCEINLINE uint32 GetTypeHash(const FRealtimeMeshElementType& Element)
 		{
-			return ::HashCombine(::GetTypeHash(Element.Type), ::GetTypeHash(Element.NumDatums << 2 | Element.bNormalized << 1 | Element.bShouldConvertToFloat));
+			return ::HashCombine(GetTypeHashHelper(Element.Type), GetTypeHashHelper(Element.NumDatums << 2 | Element.bNormalized << 1 | Element.bShouldConvertToFloat));
 		}
 		
 		friend FArchive& operator<<(FArchive& Ar, FRealtimeMeshElementType& ElementType)
@@ -156,7 +156,7 @@ namespace RealtimeMesh
 	private:
 		void InitHash()
 		{
-			uint32 NewHash = ::GetTypeHash(NumElements);
+			uint32 NewHash = GetTypeHashHelper(NumElements);
 			for (int32 Index = 0; Index < Elements.Num(); Index++)
 			{
 				NewHash = HashCombine(NewHash, GetTypeHash(Elements[Index]));

--- a/Source/RealtimeMeshComponent/Public/RealtimeMeshCore.h
+++ b/Source/RealtimeMeshComponent/Public/RealtimeMeshCore.h
@@ -7,7 +7,7 @@
 #include "StaticMeshResources.h"
 
 // This version of the RMC is only supported by engine version 5.0.0 and above
-static_assert(ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 0);
+static_assert(ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >= 2);
 
 DECLARE_STATS_GROUP(TEXT("RealtimeMesh"), STATGROUP_RealtimeMesh, STATCAT_Advanced);
 
@@ -81,7 +81,7 @@ namespace RealtimeMesh
 		
 		friend inline uint32 GetTypeHash(const FRealtimeMeshStreamKey& StreamKey)
 		{
-			return ::GetTypeHash(StreamKey.StreamType) + 23 * ::GetTypeHash(StreamKey.StreamName);
+			return GetTypeHashHelper(StreamKey.StreamType) + 23 * GetTypeHashHelper(StreamKey.StreamName);
 		}
 
 		FString ToString() const

--- a/Source/RealtimeMeshComponent/Public/RenderProxy/RealtimeMeshGPUBuffer.h
+++ b/Source/RealtimeMeshComponent/Public/RenderProxy/RealtimeMeshGPUBuffer.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "DataDrivenShaderPlatformInfo.h"
+#include "RHIResourceUpdates.h"
 #include "Data/RealtimeMeshDataTypes.h"
 #include "Containers/ResourceArray.h"
 

--- a/Source/RealtimeMeshComponent/RealtimeMeshComponent.Build.cs
+++ b/Source/RealtimeMeshComponent/RealtimeMeshComponent.Build.cs
@@ -17,7 +17,7 @@ public class RealtimeMeshComponent : ModuleRules
         PublicDependencyModuleNames.AddRange(
             new string[]
             {
-                "Core", "CoreUObject",
+                "Core", "CoreUObject", "RHI",
             }
             );
 


### PR DESCRIPTION
Just fixed the compile errors, removed `RayTracingInstance.BuildInstanceMaskAndFlags(FeatureLevel)`, and made 5.2 mandatory. It runs, but unsure about path-tracing support and 5.1 / 5.0 compat.