### PR TITLE
Two bugfixes that are currently happening when using the Realtime Mesh Component

### DIFF
--- a/Source/RealtimeMeshComponent/Private/Data/RealtimeMeshLOD.cpp
+++ b/Source/RealtimeMeshComponent/Private/Data/RealtimeMeshLOD.cpp
@@ -70,7 +70,7 @@ namespace RealtimeMesh
 	{
 		FRWScopeLockEx ScopeLock(Lock, SLT_Write);
 		const auto Allocation = SectionGroups.AddUninitialized();
-		check(Allocation.Index <+ UINT8_MAX);
+		check(Allocation.Index <= UINT8_MAX);
 		FRealtimeMeshSectionGroupKey SectionGroupKey = FRealtimeMeshSectionGroupKey(Key, Allocation.Index);
 		new(Allocation) FRealtimeMeshSectionGroupRef(ClassFactory->CreateSectionGroup(MeshWeak.Pin().ToSharedRef(), SectionGroupKey));
 		const auto& SectionGroup = SectionGroups[FRealtimeMeshKeyHelpers::GetSectionGroupIndex(SectionGroupKey)];

--- a/Source/RealtimeMeshComponent/Public/Data/RealtimeMeshDataBuilder.h
+++ b/Source/RealtimeMeshComponent/Public/Data/RealtimeMeshDataBuilder.h
@@ -383,12 +383,15 @@ namespace RealtimeMesh
 		template<typename VertexType>
 		void Append(int32 Count, VertexType* NewElements)
 		{
+			if (Count == 0) return;
 			Append(MakeArrayView(NewElements, Count));			
 		}
 		
 		template<typename VertexType, typename GeneratorFunc>
 		void Append(int32 Count, GeneratorFunc Generator)
 		{
+			if (Count == 0) return;
+
 			SizeType Index = AddUninitialized(Count);
 			VertexType* DataPtr = GetDataAtVertex<VertexType>(Index);
 			
@@ -402,6 +405,8 @@ namespace RealtimeMesh
 		template<typename VertexType, typename GeneratorFunc>
 		void AppendBy(int32 Count, GeneratorFunc Generator)
 		{
+			if (Count == 0) return;
+
 			SizeType Index = AddUninitialized(Count);
 			VertexType* DataPtr = GetDataAtVertex<VertexType>(Index);
 			while (Index < ArrayNum)


### PR DESCRIPTION
- Fixed typo in <= sign
- Fixed FRealtimeMeshDataStream::Append() accessing invalid memory when appending 0 elements to array of length 0