### PR TITLE
Fix MeshBuilder SetPosition compile error

### DIFF
--- a/Source/RealtimeMeshComponent/Public/Mesh/RealtimeMeshBuilder.h
+++ b/Source/RealtimeMeshComponent/Public/Mesh/RealtimeMeshBuilder.h
@@ -1275,8 +1275,7 @@ namespace RealtimeMesh
 
 		TRowBuilder& SetPosition(const FVector3f& Position)
 		{
-			ParentBuilder.
-			Builder->GetVerticesBuilder().Set(RowIndex, Position);
+			ParentBuilder.SetPosition(RowIndex, Position);
 			return *this;
 		}
 


### PR DESCRIPTION
Fix a compilation error when using TRealtimeMeshVertexBuilderLocal::SetPosition. 