### PR TITLE
Fixed an assertion in packaged projects when loading a level that has a pre-placed actor that is using a RealtimeMeshComponent

### DIFF
--- a/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshComponentProxy.cpp
+++ b/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshComponentProxy.cpp
@@ -43,7 +43,7 @@ namespace RealtimeMesh
 				Mat = UMaterial::GetDefaultMaterial(MD_Surface);
 			}
 			Materials.Add(MaterialIndex, MakeTuple(Mat->GetRenderProxy(), Mat->IsDitheredLODTransition()));
-			MaterialRelevance |= Mat->GetRelevance(GetScene().GetFeatureLevel());
+			MaterialRelevance |= Mat->GetRelevance_Concurrent(GetScene().GetFeatureLevel());
 			bAnyMaterialUsesDithering = Mat->IsDitheredLODTransition();
 		}
 


### PR DESCRIPTION
In packaged projects when loading a level that has a pre-placed actor using an RMC, the engine crashes due to the following assertion.
> [2024.03.15-23.28.31:801][  0]LogWindows: Error: appError called: Assertion failed: IsInGameThread() || IsAsyncLoading() [File:U:\Unreal\Engines\UE_5.3\Engine\Source\Runtime\Engine\Private\Materials\MaterialInstance.cpp] [Line: 879] 

This PR fixes that by replacing `GetRelevance()` with `GetRelevance_Concurrent()` which seems to be the preferred function within SceneProxy constructors.