### PR TITLE
Fixed Blueprint Mesh Builder Multiple UVs

### DIFF
--- a/Source/RealtimeMeshComponent/Private/Mesh/RealtimeMeshBlueprintMeshBuilder.cpp
+++ b/Source/RealtimeMeshComponent/Private/Mesh/RealtimeMeshBlueprintMeshBuilder.cpp
@@ -650,17 +650,17 @@ URealtimeMeshLocalBuilder* URealtimeMeshLocalBuilder::Initialize(ERealtimeMeshSi
 
 		if (WantedTexCoordChannels > 1)
 		{
-			UV1Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2d, void>>(Stream, 1);
+			UV1Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2d, void>>(Stream, 1);
 		}
 
 		if (WantedTexCoordChannels > 2)
 		{
-			UV2Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2d, void>>(Stream, 2);
+			UV2Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2d, void>>(Stream, 2);
 		}
 
 		if (WantedTexCoordChannels > 3)
 		{
-			UV3Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2d, void>>(Stream, 3);
+			UV3Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2d, void>>(Stream, 3);
 		}
 	}
 
@@ -781,17 +781,17 @@ URealtimeMeshLocalBuilder* URealtimeMeshLocalBuilder::EnableTexCoords(int32 NumC
 
 		if (NumChannels > 1)
 		{
-			UV1Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2d, void>>(Stream, 1);
+			UV1Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2d, void>>(Stream, 1);
 		}
 
 		if (NumChannels > 2)
 		{
-			UV2Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2d, void>>(Stream, 2);
+			UV2Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2d, void>>(Stream, 2);
 		}
 
 		if (NumChannels > 3)
 		{
-			UV3Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2d, void>>(Stream, 3);
+			UV3Builder = MakeUnique<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2d, void>>(Stream, 3);
 		}		
 	}
 	return this;
@@ -941,15 +941,15 @@ int32 URealtimeMeshLocalBuilder::AddVertex(URealtimeMeshLocalBuilder*& Builder, 
 
 			if (UV1Builder.IsValid())
 			{
-				UV1Builder->SetElement(Vertex.GetIndex(), 1, InVertex.UV1);
+				UV1Builder->SetElement(Vertex.GetIndex(), 0, InVertex.UV1);
 			}
 			if (UV2Builder.IsValid())
 			{
-				UV2Builder->SetElement(Vertex.GetIndex(), 2, InVertex.UV2);
+				UV2Builder->SetElement(Vertex.GetIndex(), 0, InVertex.UV2);
 			}
 			if (UV3Builder.IsValid())
 			{
-				UV3Builder->SetElement(Vertex.GetIndex(), 3, InVertex.UV3);
+				UV3Builder->SetElement(Vertex.GetIndex(), 0, InVertex.UV3);
 			}
 		}
 

--- a/Source/RealtimeMeshComponent/Public/Mesh/RealtimeMeshBlueprintMeshBuilder.h
+++ b/Source/RealtimeMeshComponent/Public/Mesh/RealtimeMeshBlueprintMeshBuilder.h
@@ -247,18 +247,18 @@ class REALTIMEMESHCOMPONENT_API URealtimeMeshLocalBuilder : public URealtimeMesh
 	GENERATED_BODY()
 protected:
 	TUniquePtr<RealtimeMesh::TRealtimeMeshBuilderLocal<void, void, void, 1, void>> MeshBuilder;
-	TUniquePtr<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2D, void>> UV1Builder;
-	TUniquePtr<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2D, void>> UV2Builder;
-	TUniquePtr<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2D, void>> UV3Builder;
+	TUniquePtr<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2D, void>> UV1Builder;
+	TUniquePtr<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2D, void>> UV2Builder;
+	TUniquePtr<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2D, void>> UV3Builder;
 	virtual void EnsureInitialized() override;
 public:
 	URealtimeMeshLocalBuilder() = default;
 
 	void Initialize(TUniquePtr<RealtimeMesh::FRealtimeMeshStreamSet>&& InStreams,
 		TUniquePtr<RealtimeMesh::TRealtimeMeshBuilderLocal<void, void, void, 1, void>>&& InBuilder,
-		TUniquePtr<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2D, void>>&& InUV1Builder,
-		TUniquePtr<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2D, void>>&& InUV2Builder,
-		TUniquePtr<RealtimeMesh::TRealtimeMeshStreamBuilder<FVector2D, void>>&& InUV3Builder)
+		TUniquePtr<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2D, void>>&& InUV1Builder,
+		TUniquePtr<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2D, void>>&& InUV2Builder,
+		TUniquePtr<RealtimeMesh::TRealtimeMeshStridedStreamBuilder<FVector2D, void>>&& InUV3Builder)
 	{
 		Streams = MakeShared<RealtimeMesh::FRealtimeMeshStreamSet>(MoveTemp(*InStreams));
 		MeshBuilder = MoveTemp(InBuilder);


### PR DESCRIPTION
Converted Blueprint Mesh Builder UV builders to strided builders.

Removed 1,2,3 from the builder SetElement method as it offsets the writing of UV data by an element and causes stack corruption. Have tested with normal, high precision, 1,2 3 UVs and all write to the correct places in memory.