### PR TITLE
Fix clang-specific compiler errors on Linux

### DIFF
--- a/Source/RealtimeMeshComponent/Public/RealtimeMeshSimple.h
+++ b/Source/RealtimeMeshComponent/Public/RealtimeMeshSimple.h
@@ -342,10 +342,11 @@ namespace RealtimeMesh
 		virtual void FinalizeUpdate(FRealtimeMeshUpdateContext& UpdateContext) override;
 
 		virtual bool Serialize(FArchive& Ar, URealtimeMesh* Owner) override;
-	protected:
+
 		void MarkCollisionDirtyNoCallback() const;
 		TFuture<ERealtimeMeshCollisionUpdateResult> MarkCollisionDirty() const;
 
+	protected:
 		virtual void ProcessEndOfFrameUpdates() override;
 
 		friend class URealtimeMeshSimple;

--- a/Source/RealtimeMeshComponent/Public/RenderProxy/RealtimeMeshGPUBuffer.h
+++ b/Source/RealtimeMeshComponent/Public/RenderProxy/RealtimeMeshGPUBuffer.h
@@ -214,7 +214,7 @@ namespace RealtimeMesh
 #endif
 				}
 				
-				/*Batcher.QueueUpdateRequest(VertexBufferRHI, UpdateData->GetNumElements() > 0? UpdateData->GetBuffer() : nullptr);
+				//Batcher.QueueUpdateRequest(VertexBufferRHI, UpdateData->GetNumElements() > 0? UpdateData->GetBuffer() : nullptr);
 
 #if RMC_ENGINE_BELOW_5_3
 				if (ShaderResourceViewRHI)


### PR DESCRIPTION
After upgrading to Unreal Engine 5.5, I experienced some problems when packaging my game for Linux using Cross-Compile.

Firstly `Error: '/*' within block comment [-Werror,-Wcomment]`, which only seems to appear with Clang since it has more warnings/errors enabled than MSVC.

Secondly, I got `'MarkCollisionDirtyNoCallback' is a protected member of 'RealtimeMesh::FRealtimeMeshSimple'`, where I am unsure whether it's a compiler bug or not. I found [other issues online](https://stackoverflow.com/questions/60178872/why-can-t-protected-members-be-used-by-friends-of-derived-classes) that suggest this might be a clang bug. But whatever it is, the best solution I found was just making the function public instead of protected.