### PR TITLE
Use std::conditional and add engine guards (for compatibility with UE 5.8)

### DIFF
--- a/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshSectionProxy.cpp
+++ b/Source/RealtimeMeshComponent/Private/RenderProxy/RealtimeMeshSectionProxy.cpp
@@ -63,7 +63,9 @@ namespace RealtimeMesh
 		BatchElement.InstancedLODIndex = 0;
 		BatchElement.InstancedLODRange = 0;
 		BatchElement.bUserDataIsColorVertexBuffer = false;
+#if !RMC_ENGINE_ABOVE_5_7
 		BatchElement.bIsSplineProxy = false;
+#endif
 		BatchElement.bIsInstanceRuns = false;
 		BatchElement.bForceInstanceCulling = false;
 		BatchElement.bPreserveInstanceOrder = false;

--- a/Source/RealtimeMeshComponent/Public/Interface/Core/RealtimeMeshBuilder.h
+++ b/Source/RealtimeMeshComponent/Public/Interface/Core/RealtimeMeshBuilder.h
@@ -11,10 +11,6 @@
 #include "Traits/IsVoidType.h"
 #endif
 
-#if RMC_ENGINE_ABOVE_5_4
-#include "Templates/ChooseClass.h"
-#endif
-
 struct FRealtimeMeshSimpleMeshData;
 
 // ReSharper disable CppMemberFunctionMayBeConst
@@ -73,7 +69,7 @@ namespace RealtimeMesh
 			int32 ElementOffset;
 		};
 
-		using TContext = typename TChooseClass<bAllowSubstreamAccess, TContextWithSubstream, TContextWithoutSubstream>::Result;
+		using TContext = std::conditional_t<bAllowSubstreamAccess, TContextWithSubstream, TContextWithoutSubstream>;
 		
 		static TContext InitializeContext(typename TCopyQualifiersFromTo<InAccessType, FRealtimeMeshStream>::Type& Stream, int32 ElementOffset)
 		{
@@ -168,7 +164,7 @@ namespace RealtimeMesh
 			int32 ElementOffset;
 		};
 
-		using TContext = typename TChooseClass<bAllowSubstreamAccess, TContextWithSubstream, TContextWithoutSubstream>::Result;
+		using TContext = std::conditional_t<bAllowSubstreamAccess, TContextWithSubstream, TContextWithoutSubstream>;
 		
 		static TContext InitializeContext(typename TCopyQualifiersFromTo<InStreamType, FRealtimeMeshStream>::Type& Stream, int32 ElementOffset)
 		{			
@@ -255,7 +251,7 @@ namespace RealtimeMesh
 			int32 ElementOffset;
 		};
 
-		using TContext = typename TChooseClass<bAllowSubstreamAccess, TContextWithSubstream, TContextWithoutSubstream>::Result;
+		using TContext = std::conditional_t<bAllowSubstreamAccess, TContextWithSubstream, TContextWithoutSubstream>;
 		
 		static TContext InitializeContext(typename TCopyQualifiersFromTo<InAccessType, FRealtimeMeshStream>::Type& Stream, int32 ElementOffset)
 		{			

--- a/Source/RealtimeMeshComponent/Public/Mesh/RealtimeMeshNaniteResourcesInterface.h
+++ b/Source/RealtimeMeshComponent/Public/Mesh/RealtimeMeshNaniteResourcesInterface.h
@@ -146,7 +146,9 @@ namespace RealtimeMesh
 			RuntimeResourceID = NullResources.RuntimeResourceID;
 			HierarchyOffset = NullResources.HierarchyOffset;
 			RootPageIndex = NullResources.RootPageIndex;
+#if !RMC_ENGINE_ABOVE_5_7
 			ImposterIndex = NullResources.ImposterIndex;
+#endif
 			NumHierarchyNodes = NullResources.NumHierarchyNodes;
 			NumResidentClusters = NullResources.NumResidentClusters;
 			PersistentHash = NullResources.PersistentHash;


### PR DESCRIPTION
Replace TChooseClass usage with std::conditional_t in RealtimeMeshBuilder to remove dependency on Templates/ChooseClass and improve compatibility. 

Remove the now-unneeded include. 

Add #if !RMC_ENGINE_ABOVE_5_7 guards around bIsSplineProxy and ImposterIndex initializations in RealtimeMeshSectionProxy.cpp and RealtimeMeshNaniteResourcesInterface.h to avoid referencing members not present in newer engine versions. 

Files changed: RealtimeMeshBuilder.h, RealtimeMeshSectionProxy.cpp, RealtimeMeshNaniteResourcesInterface.h.