### PR TITLE
Fix missing early return for empty mesh in CookComplexMesh

### DIFF
--- a/Source/RealtimeMeshComponent/Private/RealtimeMeshCollisionLibrary.cpp
+++ b/Source/RealtimeMeshComponent/Private/RealtimeMeshCollisionLibrary.cpp
@@ -88,6 +88,7 @@ void URealtimeMeshCollisionTools::CookComplexMesh(FRealtimeMeshCollisionMesh& Co
 	if(CollisionMesh.Vertices.Num() == 0)
 	{
 		CollisionMesh.Cooked = MakeShared<FRealtimeMeshCookedTriMeshData>();
+		return;
 	}
 
 	TArray<FVector3f> FinalVerts = CollisionMesh.Vertices;


### PR DESCRIPTION
## Summary

The empty-vertex early-out in `URealtimeMeshCollisionTools::CookComplexMesh` (`Source/RealtimeMeshComponent/Private/RealtimeMeshCollisionLibrary.cpp`) sets an empty `FRealtimeMeshCookedTriMeshData` instance but then falls through and keeps processing the empty vertex/triangle arrays (particle set creation, triangle loop, etc.). The early-out clearly intends to stop there — this adds the missing `return`.

## Context

Spotted this while tracing the collision cook path for the memory growth investigation in #290. It's a small standalone correctness/efficiency fix, no behavior change for callers: `HasMesh()` returns `false` for the empty cooked data either way, so `CopyComplexGeometryToBodySetup` skips it as before.

## Changes

- `CookComplexMesh`: added `return;` after assigning the empty cooked data in the `Vertices.Num() == 0` early-out branch.

## Testing

- One-line change; logic is self-contained. No UE workspace available to me right now, so compile check on the maintainers' side would be appreciated (change compiles in a plain C++ parse of the function body).